### PR TITLE
Align Ruby version support with fastlane core

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ jobs:
   test:
     strategy:
       matrix:
-        # https://github.com/actions/runner/issues/849
-        ruby: [2.5, 2.6, 2.7, '3.0', 3.1]
+        # Test against Ruby versions matching our gemspec requirement (>= 2.6)
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         # Test against Ruby versions matching our gemspec requirement (>= 2.6)
         ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
 - rubocop/require_tools
 - rubocop-performance
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   NewCops: enable
   Include:
   - "**/*.rb"
@@ -151,7 +151,7 @@ Style/CollectionMethods:
   Enabled: false
 Style/MethodCallWithArgsParentheses:
   Enabled: true
-  IgnoredMethods:
+  AllowedMethods:
   - require
   - require_relative
   - fastlane_require

--- a/fastlane-plugin-amazon_appstore.gemspec
+++ b/fastlane-plugin-amazon_appstore.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
   # Don't add a dependency to fastlane or fastlane_re
   # since this would cause a circular dependency

--- a/fastlane-plugin-amazon_appstore.gemspec
+++ b/fastlane-plugin-amazon_appstore.gemspec
@@ -13,28 +13,28 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = Dir["lib/**/*"] + %w(README.md LICENSE)
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  # Match fastlane's Ruby requirement for ecosystem compatibility
   spec.required_ruby_version = '>= 2.6'
 
   # Don't add a dependency to fastlane or fastlane_re
   # since this would cause a circular dependency
 
-  # spec.add_dependency 'your-dependency', '~> 1.0.0'
+  # Faraday 1.x for compatibility with fastlane ecosystem
+  spec.add_runtime_dependency('faraday', '~> 1.0')
+  spec.add_runtime_dependency('faraday_middleware', '~> 1.0')
 
-  spec.add_runtime_dependency('faraday')
-  spec.add_runtime_dependency('faraday_middleware')
-
-  spec.add_development_dependency('bundler')
+  spec.add_development_dependency('bundler', '>= 1.12.0', '< 3.0.0')
   spec.add_development_dependency('fastlane', '>= 2.199.0')
-  spec.add_development_dependency('pry')
-  spec.add_development_dependency('rake')
-  spec.add_development_dependency('rspec')
-  spec.add_development_dependency('rspec_junit_formatter')
-  spec.add_development_dependency('rubocop', '1.25.0')
-  spec.add_development_dependency('rubocop-performance')
-  spec.add_development_dependency('rubocop-require_tools')
-  spec.add_development_dependency('simplecov')
+  spec.add_development_dependency('pry', '~> 0.14')
+  spec.add_development_dependency('rake', '~> 13.0')
+  spec.add_development_dependency('rspec', '~> 3.12')
+  spec.add_development_dependency('rspec_junit_formatter', '~> 0.6')
+  spec.add_development_dependency('rubocop', '~> 1.50', '< 1.51')
+  spec.add_development_dependency('rubocop-performance', '~> 1.17')
+  spec.add_development_dependency('rubocop-require_tools', '~> 0.1')
+  spec.add_development_dependency('simplecov', '~> 0.22')
+
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
+++ b/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
@@ -180,12 +180,12 @@ module Fastlane
         return changelog_text if skip_upload_changelogs
 
         path = File.join(metadata_path, language, 'changelogs', "#{version_code}.txt")
-        if File.exist?(path) && !File.zero?(path)
+        if File.exist?(path) && !File.empty?(path)
           UI.message("Updating changelog for '#{version_code}' and language '#{language}'...")
           changelog_text = File.read(path, encoding: 'UTF-8')
         else
           defalut_changelog_path = File.join(metadata_path, language, 'changelogs', 'default.txt')
-          if File.exist?(defalut_changelog_path) && !File.zero?(defalut_changelog_path)
+          if File.exist?(defalut_changelog_path) && !File.empty?(defalut_changelog_path)
             UI.message("Updating changelog for '#{version_code}' and language '#{language}' to default changelog...")
             changelog_text = File.read(defalut_changelog_path, encoding: 'UTF-8')
           else


### PR DESCRIPTION
fastlane core dropped Ruby 2.5 support in version 2.207.0, with the current required_ruby_version set to >= 2.6.
However, this plugin still had required_ruby_version set to >= 2.5, creating inconsistency with the fastlane ecosystem.

https://github.com/fastlane/fastlane/blob/e5dfe9e69f795f06c1420639faafc13fa4761a09/fastlane.gemspec#L65