### PR TITLE
Reuse initial ETag in update_changelogs

### DIFF
--- a/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
+++ b/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
@@ -195,14 +195,19 @@ module Fastlane
         end
         raise StandardError, listings_response.body unless listings_response.success?
 
-        listings_response.body[:listings].each do |lang, listing|
-          # Get fresh ETag for each language update to avoid conflicts
-          etag_response = api_client.get(listings_path) do |request|
-            request.headers['Authorization'] = "Bearer #{token}"
-          end
-          raise StandardError, etag_response.body unless etag_response.success?
+        etag = listings_response.headers['Etag']
 
-          etag = etag_response.headers['Etag']
+        listings_response.body[:listings].each_with_index do |(lang, listing), index|
+          # Refresh ETag after the first iteration because the previous PUT
+          # invalidates the collection's ETag.
+          if index > 0
+            etag_response = api_client.get(listings_path) do |request|
+              request.headers['Authorization'] = "Bearer #{token}"
+            end
+            raise StandardError, etag_response.body unless etag_response.success?
+
+            etag = etag_response.headers['Etag']
+          end
 
           listing[:recentChanges] = find_changelog(
             language: listing[:language],


### PR DESCRIPTION
The initial GET on `/listings` already returns an ETag valid for the first PUT, but the loop was re-fetching it on every iteration. Reuse the initial ETag for the first iteration and only refresh it for subsequent iterations (since the previous PUT invalidates the collection ETag).

Reduces total API calls from `1 + 2N` to `2N` for N languages.