### PR TITLE
Add Ruby 4.0 to CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,18 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/cache@v5
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile') }}
-        restore-keys: |
-          ${{ runner.os }}-gem-
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: bundle check || bundle install --jobs=4 --retry=3 --path vendor/bundle
+        bundler-cache: true
     - name: Run tests
       run: bundle exec rake
     - name: Upload artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         # Test against Ruby versions matching our gemspec requirement (>= 2.7)
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/fastlane-plugin-amazon_appstore.gemspec
+++ b/fastlane-plugin-amazon_appstore.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('faraday', '~> 1.0')
   spec.add_runtime_dependency('faraday_middleware', '~> 1.0')
 
-  spec.add_development_dependency('bundler', '>= 1.12.0', '< 3.0.0')
+  spec.add_development_dependency('bundler', '>= 1.12.0', '< 5.0.0')
   spec.add_development_dependency('fastlane', '>= 2.199.0')
   spec.add_development_dependency('pry', '~> 0.14')
   spec.add_development_dependency('rake', '~> 13.0')


### PR DESCRIPTION
Ruby 4.0 was released on 2025-12-25 and is now in normal maintenance. Fastlane officially supports it (per [Ruby 4.0 Tracking Thread](https://github.com/fastlane/fastlane/issues/29755)) but doesn't yet have it in CI due to CircleCI lag.

Adding it here verifies the plugin works on the latest Ruby.