### PR TITLE
Drop Ruby 2.7 support due to fastlane ecosystem

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Test against Ruby versions matching our gemspec requirement (>= 2.7)
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
+        # Test against Ruby versions matching our gemspec requirement (>= 3.0)
+        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
 - rubocop/require_tools
 - rubocop-performance
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   NewCops: enable
   Include:
   - "**/*.rb"

--- a/fastlane-plugin-amazon_appstore.gemspec
+++ b/fastlane-plugin-amazon_appstore.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["lib/**/*"] + %w(README.md LICENSE)
   spec.require_paths = ['lib']
 
-  # Match fastlane's Ruby requirement for ecosystem compatibility
-  spec.required_ruby_version = '>= 2.7'
+  # The fastlane ecosystem effectively requires Ruby 3.0+ now
+  spec.required_ruby_version = '>= 3.0'
 
   # Don't add a dependency to fastlane or fastlane_re
   # since this would cause a circular dependency

--- a/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
+++ b/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
@@ -350,7 +350,7 @@ module Fastlane
         target_path = File.join(images_path, mapping)
 
         if File.directory?(target_path)
-          Dir.glob(File.join(target_path, '*.{png,jpg,jpeg}')).sort
+          Dir.glob(File.join(target_path, '*.{png,jpg,jpeg}'))
         elsif File.exist?(target_path)
           [target_path]
         else


### PR DESCRIPTION
## What

- Remove Ruby 2.7 from the CI test matrix
- Bump `required_ruby_version` from `>= 2.7` to `>= 3.0`

## Why

CI on Ruby 2.7 fails with `NameError: uninitialized constant Fastlane::OpenStruct`.

While fastlane still declares `required_ruby_version >= 2.6`, its surrounding gem ecosystem no longer supports Ruby 2.7. On 2.7, Bundler is forced to fall back to an old `fastlane 2.214.0`, which breaks under the recent `ostruct` gem changes. Ruby 3.0+ resolves to the latest fastlane and passes.

In short, the fastlane ecosystem effectively requires Ruby 3.0+ now, so we align our supported versions accordingly.