### PR TITLE
Fix error_release_notes_incomplete when changelogs are skipped

### DIFF
--- a/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
+++ b/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
@@ -182,7 +182,6 @@ module Fastlane
       end
 
       def self.update_changelogs(app_id:, edit_id:, token:, version_codes:, skip_upload_changelogs:, metadata_path:)
-        return if skip_upload_changelogs
         return if version_codes.empty?
 
         # Use the highest version code's changelog (same as Fastlane's approach)
@@ -207,7 +206,7 @@ module Fastlane
           listing[:recentChanges] = find_changelog(
             language: listing[:language],
             version_code: max_version_code,
-            skip_upload_changelogs: false,
+            skip_upload_changelogs: skip_upload_changelogs,
             metadata_path: metadata_path
           )
 

--- a/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
+++ b/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
@@ -182,11 +182,17 @@ module Fastlane
       end
 
       def self.update_changelogs(app_id:, edit_id:, token:, version_codes:, skip_upload_changelogs:, metadata_path:)
-        return if version_codes.empty?
+        # Without an uploaded APK there is no version-specific changelog to read,
+        # so fall back to only ensuring the "-" placeholder is present.
+        skip_upload_changelogs ||= version_codes.empty?
 
         # Use the highest version code's changelog (same as Fastlane's approach)
         max_version_code = version_codes.max
-        UI.message("Updating changelogs using highest version code: #{max_version_code}")
+        if max_version_code.nil?
+          UI.message("Ensuring release notes placeholder is present...")
+        else
+          UI.message("Updating changelogs using highest version code: #{max_version_code}")
+        end
 
         listings_path = "api/appstore/v1/applications/#{app_id}/edits/#{edit_id}/listings"
         listings_response = api_client.get(listings_path) do |request|

--- a/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
+++ b/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
@@ -182,10 +182,6 @@ module Fastlane
       end
 
       def self.update_changelogs(app_id:, edit_id:, token:, version_codes:, skip_upload_changelogs:, metadata_path:)
-        # Without an uploaded APK there is no version-specific changelog to read,
-        # so fall back to only ensuring the "-" placeholder is present.
-        skip_upload_changelogs ||= version_codes.empty?
-
         # Use the highest version code's changelog (same as Fastlane's approach)
         max_version_code = version_codes.max
         if max_version_code.nil?
@@ -201,9 +197,9 @@ module Fastlane
         raise StandardError, listings_response.body unless listings_response.success?
 
         listings_response.body[:listings].each do |lang, listing|
-          # When skipping changelog upload, keep existing release notes untouched
-          # and only fill in the "-" placeholder when they are missing.
-          next if skip_upload_changelogs && !listing[:recentChanges].to_s.strip.empty?
+          # When only the "-" placeholder would be written, keep existing
+          # release notes untouched and fill it in only when they are missing.
+          next if (skip_upload_changelogs || max_version_code.nil?) && !listing[:recentChanges].to_s.strip.empty?
 
           # Get fresh ETag for each language update to avoid conflicts
           etag_response = api_client.get(listings_path) do |request|
@@ -413,7 +409,7 @@ module Fastlane
         # The Amazon appstore requires you to enter changelogs before reviewing.
         # Therefore, if there is no metadata, hyphen text is returned.
         changelog_text = '-'
-        return changelog_text if skip_upload_changelogs
+        return changelog_text if skip_upload_changelogs || version_code.nil?
 
         path = File.join(metadata_path, language, 'changelogs', "#{version_code}.txt")
         if File.exist?(path) && !File.empty?(path)

--- a/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
+++ b/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
@@ -195,6 +195,10 @@ module Fastlane
         raise StandardError, listings_response.body unless listings_response.success?
 
         listings_response.body[:listings].each do |lang, listing|
+          # When skipping changelog upload, keep existing release notes untouched
+          # and only fill in the "-" placeholder when they are missing.
+          next if skip_upload_changelogs && !listing[:recentChanges].to_s.strip.empty?
+
           # Get fresh ETag for each language update to avoid conflicts
           etag_response = api_client.get(listings_path) do |request|
             request.headers['Authorization'] = "Bearer #{token}"

--- a/lib/fastlane/plugin/amazon_appstore/version.rb
+++ b/lib/fastlane/plugin/amazon_appstore/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module AmazonAppstore
-    VERSION = "1.6.0"
+    VERSION = "1.6.1"
   end
 end

--- a/spec/helper/amazon_appstore_helper_spec.rb
+++ b/spec/helper/amazon_appstore_helper_spec.rb
@@ -391,8 +391,8 @@ describe Fastlane::Helper::AmazonAppstoreHelper do
     context 'version_codes is empty' do
       let(:version_codes) { [] }
 
-      it 'should return early without processing' do
-        result = Fastlane::Helper::AmazonAppstoreHelper.update_changelogs(
+      it 'should fall back to the placeholder without reading changelog files' do
+        Fastlane::Helper::AmazonAppstoreHelper.update_changelogs(
           app_id: app_id,
           edit_id: edit_id,
           token: token,
@@ -400,8 +400,63 @@ describe Fastlane::Helper::AmazonAppstoreHelper do
           skip_upload_changelogs: skip_upload_changelogs,
           metadata_path: metadata_path
         )
-        expect(result).to be_nil
-        expect(Fastlane::Helper::AmazonAppstoreHelper).not_to have_received(:find_changelog)
+        expect(Fastlane::Helper::AmazonAppstoreHelper).to have_received(:find_changelog).with(
+          language: 'en-US',
+          version_code: nil,
+          skip_upload_changelogs: true,
+          metadata_path: metadata_path
+        )
+        expect(Fastlane::Helper::AmazonAppstoreHelper).to have_received(:find_changelog).with(
+          language: 'ja-JP',
+          version_code: nil,
+          skip_upload_changelogs: true,
+          metadata_path: metadata_path
+        )
+      end
+
+      it 'should send the listing update so the placeholder is committed' do
+        expect_any_instance_of(Faraday::Connection).to receive(:put).twice.and_return(
+          double(Faraday::Response, status: 204, body: {}, success?: true)
+        )
+        Fastlane::Helper::AmazonAppstoreHelper.update_changelogs(
+          app_id: app_id,
+          edit_id: edit_id,
+          token: token,
+          version_codes: version_codes,
+          skip_upload_changelogs: skip_upload_changelogs,
+          metadata_path: metadata_path
+        )
+      end
+
+      context 'and release notes already exist' do
+        let(:listings_response_body) do
+          {
+            listings: {
+              'en-US': {
+                language: 'en-US',
+                title: 'title',
+                recentChanges: 'Existing release notes'
+              },
+              'ja-JP': {
+                language: 'ja-JP',
+                title: 'title',
+                recentChanges: '既存のリリースノート'
+              }
+            }
+          }
+        end
+
+        it 'should not overwrite existing release notes' do
+          expect_any_instance_of(Faraday::Connection).not_to receive(:put)
+          Fastlane::Helper::AmazonAppstoreHelper.update_changelogs(
+            app_id: app_id,
+            edit_id: edit_id,
+            token: token,
+            version_codes: version_codes,
+            skip_upload_changelogs: skip_upload_changelogs,
+            metadata_path: metadata_path
+          )
+        end
       end
     end
 

--- a/spec/helper/amazon_appstore_helper_spec.rb
+++ b/spec/helper/amazon_appstore_helper_spec.rb
@@ -403,13 +403,13 @@ describe Fastlane::Helper::AmazonAppstoreHelper do
         expect(Fastlane::Helper::AmazonAppstoreHelper).to have_received(:find_changelog).with(
           language: 'en-US',
           version_code: nil,
-          skip_upload_changelogs: true,
+          skip_upload_changelogs: false,
           metadata_path: metadata_path
         )
         expect(Fastlane::Helper::AmazonAppstoreHelper).to have_received(:find_changelog).with(
           language: 'ja-JP',
           version_code: nil,
-          skip_upload_changelogs: true,
+          skip_upload_changelogs: false,
           metadata_path: metadata_path
         )
       end
@@ -605,6 +605,23 @@ describe Fastlane::Helper::AmazonAppstoreHelper do
           language: language,
           version_code: version_code,
           skip_upload_changelogs: true,
+          metadata_path: metadata_path
+        )
+        expect(result).to eq('-')
+      end
+    end
+
+    it 'should return "-" when version_code is nil' do
+      Dir.mktmpdir do |metadata_path|
+        changelogs_dir = File.join(metadata_path, language, 'changelogs')
+        FileUtils.mkdir_p(changelogs_dir)
+        File.write(File.join(changelogs_dir, 'default.txt'), 'Default changelog')
+
+        result = Fastlane::Helper::AmazonAppstoreHelper.send(
+          :find_changelog,
+          language: language,
+          version_code: nil,
+          skip_upload_changelogs: false,
           metadata_path: metadata_path
         )
         expect(result).to eq('-')

--- a/spec/helper/amazon_appstore_helper_spec.rb
+++ b/spec/helper/amazon_appstore_helper_spec.rb
@@ -407,8 +407,8 @@ describe Fastlane::Helper::AmazonAppstoreHelper do
     context 'skip_upload_changelogs is true' do
       let(:skip_upload_changelogs) { true }
 
-      it 'should return early without processing' do
-        result = Fastlane::Helper::AmazonAppstoreHelper.update_changelogs(
+      it 'should still write the placeholder changelog for each language' do
+        Fastlane::Helper::AmazonAppstoreHelper.update_changelogs(
           app_id: app_id,
           edit_id: edit_id,
           token: token,
@@ -416,8 +416,32 @@ describe Fastlane::Helper::AmazonAppstoreHelper do
           skip_upload_changelogs: skip_upload_changelogs,
           metadata_path: metadata_path
         )
-        expect(result).to be_nil
-        expect(Fastlane::Helper::AmazonAppstoreHelper).not_to have_received(:find_changelog)
+        expect(Fastlane::Helper::AmazonAppstoreHelper).to have_received(:find_changelog).with(
+          language: 'en-US',
+          version_code: 300,
+          skip_upload_changelogs: true,
+          metadata_path: metadata_path
+        )
+        expect(Fastlane::Helper::AmazonAppstoreHelper).to have_received(:find_changelog).with(
+          language: 'ja-JP',
+          version_code: 300,
+          skip_upload_changelogs: true,
+          metadata_path: metadata_path
+        )
+      end
+
+      it 'should send the listing update so the placeholder is committed' do
+        expect_any_instance_of(Faraday::Connection).to receive(:put).twice.and_return(
+          double(Faraday::Response, status: 204, body: {}, success?: true)
+        )
+        Fastlane::Helper::AmazonAppstoreHelper.update_changelogs(
+          app_id: app_id,
+          edit_id: edit_id,
+          token: token,
+          version_codes: version_codes,
+          skip_upload_changelogs: skip_upload_changelogs,
+          metadata_path: metadata_path
+        )
       end
     end
   end

--- a/spec/helper/amazon_appstore_helper_spec.rb
+++ b/spec/helper/amazon_appstore_helper_spec.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'tmpdir'
 
 describe Fastlane::Helper::AmazonAppstoreHelper do
   describe '#setup' do
@@ -443,6 +444,66 @@ describe Fastlane::Helper::AmazonAppstoreHelper do
           metadata_path: metadata_path
         )
       end
+
+      it 'should write "-" as the recentChanges value' do
+        allow(Fastlane::Helper::AmazonAppstoreHelper).to receive(:find_changelog).and_call_original
+        captured_bodies = []
+        request_spy = double('request', headers: {})
+        allow(request_spy).to receive(:body=) { |value| captured_bodies << value }
+        allow_any_instance_of(Faraday::Connection).to receive(:put) do |_instance, _path, &block|
+          block.call(request_spy)
+          double(Faraday::Response, status: 204, body: {}, success?: true)
+        end
+
+        Fastlane::Helper::AmazonAppstoreHelper.update_changelogs(
+          app_id: app_id,
+          edit_id: edit_id,
+          token: token,
+          version_codes: version_codes,
+          skip_upload_changelogs: skip_upload_changelogs,
+          metadata_path: metadata_path
+        )
+
+        parsed = captured_bodies.map { |body| JSON.parse(body) }
+        expect(parsed.length).to eq(2)
+        expect(parsed).to all(include('recentChanges' => '-'))
+      end
+    end
+
+    context 'skip_upload_changelogs is true and release notes exist for only some languages' do
+      let(:skip_upload_changelogs) { true }
+      let(:listings_response_body) do
+        {
+          listings: {
+            'en-US': {
+              language: 'en-US',
+              title: 'title',
+              recentChanges: nil
+            },
+            'ja-JP': {
+              language: 'ja-JP',
+              title: 'title',
+              recentChanges: '既存のリリースノート'
+            }
+          }
+        }
+      end
+
+      it 'should fill the placeholder only for languages without release notes' do
+        expect_any_instance_of(Faraday::Connection).to receive(:put).once.with(
+          "api/appstore/v1/applications/#{app_id}/edits/#{edit_id}/listings/en-US"
+        ).and_return(
+          double(Faraday::Response, status: 204, body: {}, success?: true)
+        )
+        Fastlane::Helper::AmazonAppstoreHelper.update_changelogs(
+          app_id: app_id,
+          edit_id: edit_id,
+          token: token,
+          version_codes: version_codes,
+          skip_upload_changelogs: skip_upload_changelogs,
+          metadata_path: metadata_path
+        )
+      end
     end
 
     context 'skip_upload_changelogs is true and release notes already exist' do
@@ -474,6 +535,71 @@ describe Fastlane::Helper::AmazonAppstoreHelper do
           skip_upload_changelogs: skip_upload_changelogs,
           metadata_path: metadata_path
         )
+      end
+    end
+  end
+
+  describe '#find_changelog' do
+    let(:language) { 'en-US' }
+    let(:version_code) { 100 }
+
+    it 'should return "-" when skip_upload_changelogs is true' do
+      Dir.mktmpdir do |metadata_path|
+        result = Fastlane::Helper::AmazonAppstoreHelper.send(
+          :find_changelog,
+          language: language,
+          version_code: version_code,
+          skip_upload_changelogs: true,
+          metadata_path: metadata_path
+        )
+        expect(result).to eq('-')
+      end
+    end
+
+    it 'should return "-" when no changelog file exists' do
+      Dir.mktmpdir do |metadata_path|
+        result = Fastlane::Helper::AmazonAppstoreHelper.send(
+          :find_changelog,
+          language: language,
+          version_code: version_code,
+          skip_upload_changelogs: false,
+          metadata_path: metadata_path
+        )
+        expect(result).to eq('-')
+      end
+    end
+
+    it 'should return the changelog file content for the version code' do
+      Dir.mktmpdir do |metadata_path|
+        changelogs_dir = File.join(metadata_path, language, 'changelogs')
+        FileUtils.mkdir_p(changelogs_dir)
+        File.write(File.join(changelogs_dir, "#{version_code}.txt"), 'Version changelog')
+
+        result = Fastlane::Helper::AmazonAppstoreHelper.send(
+          :find_changelog,
+          language: language,
+          version_code: version_code,
+          skip_upload_changelogs: false,
+          metadata_path: metadata_path
+        )
+        expect(result).to eq('Version changelog')
+      end
+    end
+
+    it 'should fall back to default.txt when the version file is missing' do
+      Dir.mktmpdir do |metadata_path|
+        changelogs_dir = File.join(metadata_path, language, 'changelogs')
+        FileUtils.mkdir_p(changelogs_dir)
+        File.write(File.join(changelogs_dir, 'default.txt'), 'Default changelog')
+
+        result = Fastlane::Helper::AmazonAppstoreHelper.send(
+          :find_changelog,
+          language: language,
+          version_code: version_code,
+          skip_upload_changelogs: false,
+          metadata_path: metadata_path
+        )
+        expect(result).to eq('Default changelog')
       end
     end
   end

--- a/spec/helper/amazon_appstore_helper_spec.rb
+++ b/spec/helper/amazon_appstore_helper_spec.rb
@@ -598,8 +598,12 @@ describe Fastlane::Helper::AmazonAppstoreHelper do
     let(:language) { 'en-US' }
     let(:version_code) { 100 }
 
-    it 'should return "-" when skip_upload_changelogs is true' do
+    it 'should return "-" when skip_upload_changelogs is true even if a changelog file exists' do
       Dir.mktmpdir do |metadata_path|
+        changelogs_dir = File.join(metadata_path, language, 'changelogs')
+        FileUtils.mkdir_p(changelogs_dir)
+        File.write(File.join(changelogs_dir, "#{version_code}.txt"), 'Version changelog')
+
         result = Fastlane::Helper::AmazonAppstoreHelper.send(
           :find_changelog,
           language: language,

--- a/spec/helper/amazon_appstore_helper_spec.rb
+++ b/spec/helper/amazon_appstore_helper_spec.rb
@@ -444,6 +444,38 @@ describe Fastlane::Helper::AmazonAppstoreHelper do
         )
       end
     end
+
+    context 'skip_upload_changelogs is true and release notes already exist' do
+      let(:skip_upload_changelogs) { true }
+      let(:listings_response_body) do
+        {
+          listings: {
+            'en-US': {
+              language: 'en-US',
+              title: 'title',
+              recentChanges: 'Existing release notes'
+            },
+            'ja-JP': {
+              language: 'ja-JP',
+              title: 'title',
+              recentChanges: '既存のリリースノート'
+            }
+          }
+        }
+      end
+
+      it 'should not overwrite existing release notes' do
+        expect_any_instance_of(Faraday::Connection).not_to receive(:put)
+        Fastlane::Helper::AmazonAppstoreHelper.update_changelogs(
+          app_id: app_id,
+          edit_id: edit_id,
+          token: token,
+          version_codes: version_codes,
+          skip_upload_changelogs: skip_upload_changelogs,
+          metadata_path: metadata_path
+        )
+      end
+    end
   end
 
   describe '#upload_image' do


### PR DESCRIPTION
Fixes #37.

## Summary
Since v1.3.0, `update_changelogs` returned early when `skip_upload_changelogs` was true, so the placeholder was never written.  With `overwrite_upload` (mode `new`) a brand-new edit is created every time, leaving `recentChanges` empty, and the commit failed. 

## Changes
 - Remove the early `return` on `skip_upload_changelogs` so the `-` placeholder is written again.
 - Only fill in the `-` placeholder when `recentChanges` is empty, so existing release notes (e.g. in `reuse` mode)
  are preserved instead of being overwritten.
 - Add tests covering the skip / placeholder / preserve combinations and direct `find_changelog` unit tests.
