### PR TITLE
Support faraday 2.x for fastlane 2.238.0

### DIFF
--- a/fastlane-plugin-amazon_appstore.gemspec
+++ b/fastlane-plugin-amazon_appstore.gemspec
@@ -21,9 +21,8 @@ Gem::Specification.new do |spec|
   # Don't add a dependency to fastlane or fastlane_re
   # since this would cause a circular dependency
 
-  # Faraday 1.x for compatibility with fastlane ecosystem
-  spec.add_runtime_dependency('faraday', '~> 1.0')
-  spec.add_runtime_dependency('faraday_middleware', '~> 1.0')
+  spec.add_runtime_dependency('faraday', '>= 1.0')
+  spec.add_runtime_dependency('faraday-multipart', '>= 1.0')
 
   spec.add_development_dependency('bundler', '>= 1.12.0', '< 5.0.0')
   spec.add_development_dependency('fastlane', '>= 2.199.0')

--- a/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
+++ b/lib/fastlane/plugin/amazon_appstore/helper/amazon_appstore_helper.rb
@@ -1,6 +1,6 @@
 require 'fastlane_core/ui/ui'
 require 'faraday'
-require 'faraday_middleware'
+require 'faraday/multipart'
 require 'json'
 
 module Fastlane

--- a/spec/helper/amazon_appstore_helper_spec.rb
+++ b/spec/helper/amazon_appstore_helper_spec.rb
@@ -10,6 +10,17 @@ describe Fastlane::Helper::AmazonAppstoreHelper do
     end
   end
 
+  describe '#api_client' do
+    it 'should build multipart, url_encoded and json middleware' do
+      handlers = Fastlane::Helper::AmazonAppstoreHelper.send(:api_client).builder.handlers
+      expect(handlers).to eq([Faraday::Multipart::Middleware, Faraday::Request::UrlEncoded, Faraday::Response::Json])
+    end
+
+    it 'should provide multipart upload support' do
+      expect(Faraday::UploadIO).to be_a(Class)
+    end
+  end
+
   describe '#token' do
     let(:auth_url) { Fastlane::Helper::AmazonAppstoreHelper::AUTH_URL }
     let(:client_id) { 'client_id' }


### PR DESCRIPTION
Fixes #39

fastlane 2.238.0 switched to `faraday ~> 2.7` and dropped `faraday_middleware`, which conflicts with the `faraday (~> 1.0)` pin in this gemspec.

- https://github.com/fastlane/fastlane/pull/30089

## Changes

- Relax `faraday` to `>= 1.0` and drop `faraday_middleware`
- Add `faraday-multipart`, since faraday 2.x no longer bundles multipart support
- Replace `require 'faraday_middleware'` with `require 'faraday/multipart'`
- Add specs covering the middleware stack and multipart support

No upper bound is set, so fastlane stays the single source of truth for the faraday version. The plugin only uses `:multipart`, `:url_encoded` and `:json`, all of which resolve identically on faraday 1.x and 2.x.

## Verified

| fastlane | faraday |
| --- | --- |
| 2.199.0 | 1.10.6 |
| 2.226.0 | 1.10.6 |
| 2.237.0 | 1.10.6 |
| 2.238.0 | 2.14.3 |