### PR TITLE
Bump version to 1.7.0

### DIFF
--- a/lib/fastlane/plugin/amazon_appstore/version.rb
+++ b/lib/fastlane/plugin/amazon_appstore/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module AmazonAppstore
-    VERSION = "1.6.1"
+    VERSION = "1.7.0"
   end
 end


### PR DESCRIPTION
Release the faraday 2.x support from #40.

Minor bump rather than patch, since the runtime dependencies changed: `faraday_middleware` was dropped and `faraday-multipart` added.